### PR TITLE
Add support for sentence similarity task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ examples/conversational/conversational
 examples/fill_mask/fill_mask
 examples/object_detection/object_detection
 examples/question_answering/question_answering
+examples/sentence_similarity/sentence_similarity
 examples/speech_recognition/speech_recognition
 examples/summarization/summarization
 examples/table_question_answering/table_question_answering

--- a/examples/build_examples.sh
+++ b/examples/build_examples.sh
@@ -4,6 +4,7 @@ set -e
 
 if ! pushd "$(dirname "${BASH_SOURCE[0]}")"; then
   echo "Failed to enter script directory."
+  exit 1
 fi
 
 for d in */; do

--- a/examples/sentence_similarity/main.go
+++ b/examples/sentence_similarity/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/TannerKvarfordt/hfapigo"
+)
+
+const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"
+
+func init() {
+	key := os.Getenv(HuggingFaceTokenEnv)
+	if key != "" {
+		hfapigo.SetAPIKey(key)
+	}
+}
+
+func main() {
+	sourceSentence := "That is a happy person"
+	inputSentences := []string{"That is a happy dog", "That is a very happy person", "Today is a sunny day"}
+
+	fmt.Printf("Source Sentence: %s\n", sourceSentence)
+	fmt.Printf("Input Sentences: %s\n", strings.Join(inputSentences, `", "`))
+	fmt.Print("\nSending request")
+
+	type ChanRv struct {
+		resp *hfapigo.SentenceSimilarityResponse
+		err  error
+	}
+	ch := make(chan ChanRv)
+
+	go func() {
+		resp, err := hfapigo.SendSentenceSimilarityRequest(hfapigo.RecommendedSentenceSimilarityModel, &hfapigo.SentenceSimilarityRequest{
+			Inputs: hfapigo.SentenceSimilarityInputs{
+				SourceSentence: sourceSentence,
+				Sentences:      inputSentences,
+			},
+			Options: *hfapigo.NewOptions().SetWaitForModel(true),
+		})
+
+		ch <- ChanRv{resp, err}
+	}()
+
+	for {
+		select {
+		case chrv := <-ch:
+			fmt.Println()
+			if chrv.err != nil {
+				fmt.Println(chrv.err)
+				return
+			}
+
+			fmt.Println()
+			for i, s := range inputSentences {
+				fmt.Printf("%s -> %f similarity\n", s, (*chrv.resp)[i])
+			}
+			return
+		default:
+			fmt.Print(".")
+			time.Sleep(time.Millisecond * 100)
+		}
+	}
+}

--- a/sentence_similarity.go
+++ b/sentence_similarity.go
@@ -12,17 +12,18 @@ const (
 // Request structure for the Sentence Similarity endpoint.
 type SentenceSimilarityRequest struct {
 	// (Required) Inputs for the request.
-	Inputs struct {
-		// (Required) The string that you wish to compare the other strings with.
-		// This can be a phrase, sentence, or longer passage, depending on the
-		// model being used.
-		SourceSentence string `json:"source_sentence,omitempty"`
+	Inputs  SentenceSimilarityInputs `json:"inputs,omitempty"`
+	Options Options                  `json:"options,omitempty"`
+}
 
-		// A list of strings which will be compared against the source_sentence.
-		Sentences []string `json:"sentences,omitempty"`
-	} `json:"inputs,omitempty"`
+type SentenceSimilarityInputs struct {
+	// (Required) The string that you wish to compare the other strings with.
+	// This can be a phrase, sentence, or longer passage, depending on the
+	// model being used.
+	SourceSentence string `json:"source_sentence,omitempty"`
 
-	Options Options `json:"options,omitempty"`
+	// A list of strings which will be compared against the source_sentence.
+	Sentences []string `json:"sentences,omitempty"`
 }
 
 // Response structure from the Sentence Similarity endpoint.

--- a/sentence_similarity.go
+++ b/sentence_similarity.go
@@ -1,0 +1,56 @@
+package hfapigo
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+const (
+	RecommendedSentenceSimilarityModel = "sentence-transformers/all-MiniLM-L6-v2"
+)
+
+// Request structure for the Sentence Similarity endpoint.
+type SentenceSimilarityRequest struct {
+	// (Required) Inputs for the request.
+	Inputs struct {
+		// (Required) The string that you wish to compare the other strings with.
+		// This can be a phrase, sentence, or longer passage, depending on the
+		// model being used.
+		SourceSentence string `json:"source_sentence,omitempty"`
+
+		// A list of strings which will be compared against the source_sentence.
+		Sentences []string `json:"sentences,omitempty"`
+	} `json:"inputs,omitempty"`
+
+	Options Options `json:"options,omitempty"`
+}
+
+// Response structure from the Sentence Similarity endpoint.
+// The return value is a list of similarity scores, given as floats.
+// Each list entry corresponds to the Inputs.Sentences list entry
+// of the same index.
+type SentenceSimilarityResponse []float64
+
+func SendSentenceSimilarityRequest(model string, request *SentenceSimilarityRequest) (*SentenceSimilarityResponse, error) {
+	if request == nil {
+		return nil, errors.New("nil SentenceSimilarityRequest")
+	}
+
+	jsonBuf, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := MakeHFAPIRequest(jsonBuf, model)
+	if err != nil {
+		return nil, err
+	}
+
+	resps := make(SentenceSimilarityResponse, len(request.Inputs.Sentences))
+	err = json.Unmarshal(respBody, &resps)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resps, nil
+}

--- a/sentence_similarity_test.go
+++ b/sentence_similarity_test.go
@@ -1,0 +1,129 @@
+package hfapigo_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/TannerKvarfordt/hfapigo"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMarshalUnmarshalSentenceSimilarityRequest(t *testing.T) {
+	// No options
+	{
+		expected := hfapigo.SentenceSimilarityRequest{
+			Inputs: hfapigo.SentenceSimilarityInputs{
+				SourceSentence: "That is a happy person",
+				Sentences: []string{
+					"That is a happy dog",
+					"That is a very happy person",
+					"Today is a sunny day",
+				},
+			},
+		}
+
+		jsonBuf, err := json.Marshal(expected)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actual := hfapigo.SentenceSimilarityRequest{}
+		err = json.Unmarshal(jsonBuf, &actual)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !cmp.Equal(expected, actual) {
+			t.Fatalf("Expected %v, got %v", expected, actual)
+		}
+	}
+
+	// Options
+	{
+		{
+			expected := hfapigo.SentenceSimilarityRequest{
+				Inputs: hfapigo.SentenceSimilarityInputs{
+					SourceSentence: "That is a happy person",
+					Sentences: []string{
+						"That is a happy dog",
+						"That is a very happy person",
+						"Today is a sunny day",
+					},
+				},
+				Options: *hfapigo.NewOptions().SetWaitForModel(true).SetUseGPU(false),
+			}
+
+			jsonBuf, err := json.Marshal(expected)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actual := hfapigo.SentenceSimilarityRequest{}
+			err = json.Unmarshal(jsonBuf, &actual)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !cmp.Equal(expected, actual) {
+				t.Fatalf("Expected %v, got %v", expected, actual)
+			}
+		}
+	}
+}
+
+func TestSentenceSimilarityRequest(t *testing.T) {
+	// Minimal Request
+	{
+		inputSentences := []string{"That is a happy dog"}
+		resp, err := hfapigo.SendSentenceSimilarityRequest(hfapigo.RecommendedSentenceSimilarityModel, &hfapigo.SentenceSimilarityRequest{
+			Inputs: hfapigo.SentenceSimilarityInputs{
+				SourceSentence: "That is a happy person",
+				Sentences:      inputSentences,
+			},
+			Options: *hfapigo.NewOptions().SetWaitForModel(true),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp == nil {
+			t.Fatal("unexpected nil SentenceSimilarityResponse")
+		}
+		if len(*resp) != len(inputSentences) {
+			t.Fatalf("Expected %d number of responses, got %d", len(inputSentences), len(*resp))
+		}
+	}
+
+	// Multiple Sentences
+	{
+		inputSentences := []string{"That is a happy dog", "That is a very happy person", "Today is a sunny day"}
+		resp, err := hfapigo.SendSentenceSimilarityRequest(hfapigo.RecommendedSentenceSimilarityModel, &hfapigo.SentenceSimilarityRequest{
+			Inputs: hfapigo.SentenceSimilarityInputs{
+				SourceSentence: "That is a happy person",
+				Sentences:      inputSentences,
+			},
+			Options: *hfapigo.NewOptions().SetWaitForModel(true),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp == nil {
+			t.Fatal("unexpected nil SentenceSimilarityResponse")
+		}
+		if len(*resp) != len(inputSentences) {
+			t.Fatalf("Expected %d number of responses, got %d", len(inputSentences), len(*resp))
+		}
+	}
+
+	// Invalid request
+	{
+		resp, err := hfapigo.SendSentenceSimilarityRequest(hfapigo.RecommendedSentenceSimilarityModel, &hfapigo.SentenceSimilarityRequest{
+			Options: *hfapigo.NewOptions().SetWaitForModel(true),
+		})
+		if err == nil {
+			t.Fatal(err)
+		}
+		if resp != nil {
+			t.Fatal("Expected nil response")
+		}
+	}
+}


### PR DESCRIPTION
This PR adds support for the [sentence similarity task](https://huggingface.co/docs/api-inference/detailed_parameters#sentence-similarity-task). Closes #7.