### PR TITLE
security: pin action and tool versions to prevent supply chain attacks

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1.0.0
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
         run: go vet -v ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@v9.3.0
         with:
-          version: latest
+          version: 1.61.0
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
           go-version-file: "go.mod"
           cache: true
       - run: go version
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v6.1.0
         with:
           distribution: goreleaser
-          version: latest
+          version: 2.6.1
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Pin golangci-lint action to v9.3.0 and tool version to 1.61.0 (was: latest)
- Pin goreleaser action to v6.1.0 and tool version to 2.6.1 (was: latest)
- Pin claude-code-action to v1.0.0 (was: v1)

Using 'latest' or unpinned versions creates supply chain attack risks by allowing automatic updates to potentially compromised versions. This change ensures that only explicitly approved versions are used in CI/CD pipelines.