### PR TITLE
Integration test workflow updates

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,9 +51,11 @@ concurrency:
       format('integration-tests-pr-{0}',
         github.event_name == 'issue_comment' && github.event.issue.number || github.event.inputs.pr_number
       ) ||
+      (github.event_name == 'push' || github.event_name == 'schedule') &&
       format('integration-tests-{0}',
         github.ref == 'refs/heads/v4-draft' && 'v4-draft' || 'main'
-      )
+      ) ||
+      'integration-tests-dispatch'
     }}
   cancel-in-progress: true
 
@@ -61,7 +63,7 @@ concurrency:
 # JOBS
 # ============================================================================
 jobs:
-  check-comment:
+  integration-tests:
     name: Run Integration Tests
     # Authorization checks:
     # - Always run: push, schedule, or manual workflow_dispatch
@@ -97,6 +99,13 @@ jobs:
               repo: context.repo.repo,
               pull_number: parseInt(prNumber)
             });
+
+            // Guard against null merge_commit_sha (PR not mergeable or merge not computed)
+            if (!pr.data.merge_commit_sha) {
+              core.setFailed(`PR #${prNumber} is not mergeable or merge commit SHA is not available. Ensure the PR is mergeable before running tests.`);
+              process.exit(1);
+            }
+
             core.setOutput('merge_commit_sha', pr.data.merge_commit_sha);
 
       # ====================================================================
@@ -161,7 +170,43 @@ jobs:
           exit 1
 
       # ====================================================================
-      # Step 5: Create/update failure issue (branch/schedule only)
+      # Step 5: Ensure failure labels exist (branch/schedule only)
+      # ====================================================================
+      # Creates branch-specific labels if they don't already exist.
+      # This ensures that the subsequent issue creation/update steps can use these labels.
+      # Uses try/catch since the API errors if label already exists.
+      - name: Ensure failure labels exist
+        if: |
+          github.event_name == 'push' || github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const branchName = "${{ github.ref_name }}";
+            const label = `integration-test-failure:${branchName}`;
+            const color = "d73a49"; // Red color for failure labels
+            const description = `Integration tests failing on ${branchName} branch`;
+
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: color,
+                description: description
+              });
+              console.log(`Created label: ${label}`);
+            } catch (error) {
+              // Label already exists or other error
+              if (error.status === 422) {
+                console.log(`Label already exists: ${label}`);
+              } else {
+                throw error;
+              }
+            }
+
+      # ====================================================================
+      # Step 6: Create/update failure issue (branch/schedule only)
       # ====================================================================
       # When tests fail on tracked branches or scheduled runs:
       # - Creates a new GitHub issue (if none exists for this branch)
@@ -214,7 +259,7 @@ jobs:
             }
 
       # ====================================================================
-      # Step 6: Close failure issue on success (branch/schedule only)
+      # Step 7: Close failure issue on success (branch/schedule only)
       # ====================================================================
       # When tests pass after previous failures:
       # - Adds a success comment to the issue

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,9 @@ name: Integration Tests
 
 on:
   push:
-    branches: [main, v4-draft]
+    branches:
+      - main
+      - v4-draft
   schedule:
     - cron: "35 21 * * 3"
   workflow_dispatch:
@@ -21,7 +23,20 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: integration-tests
+  # For PR-specific runs (comment or dispatch with PR number): use per-PR group
+  # For main/v4-draft branch runs: use branch-specific group
+  # For schedule: use main group
+  group: |
+    ${{
+      (github.event_name == 'issue_comment' ||
+       (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '')) &&
+      format('integration-tests-pr-{0}',
+        github.event_name == 'issue_comment' && github.event.issue.number || github.event.inputs.pr_number
+      ) ||
+      format('integration-tests-{0}',
+        github.ref == 'refs/heads/v4-draft' && 'v4-draft' || 'main'
+      )
+    }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,31 +1,49 @@
 ---
 name: Integration Tests
 
+# ============================================================================
+# TRIGGERS
+# ============================================================================
+# This workflow runs integration tests against the live HuggingFace API
 on:
+  # Automatic: Run on push to main branches
   push:
     branches:
       - main
       - v4-draft
+
+  # Scheduled: Run weekly on Wednesdays at 9:35 PM UTC
   schedule:
     - cron: "35 21 * * 3"
+
+  # Manual: Allow triggering via GitHub UI with optional PR number
   workflow_dispatch:
     inputs:
       pr_number:
         description: "Optional: PR number to test"
         required: false
         type: number
+
+  # Comment-triggered: Run when PR comment "/integration-test" is created
   issue_comment:
     types: [created]
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
+  issues: write # For creating/closing failure issues
+  pull-requests: read # For reading PR information
 
+# ============================================================================
+# CONCURRENCY
+# ============================================================================
+# Prevents multiple integration test runs from executing simultaneously.
+# This avoids API rate limiting and resource conflicts.
+#
+# Grouping strategy:
+# - PR-triggered runs (comment or dispatch): group by PR number
+# - Branch runs (main/v4-draft): group by branch name
+# - Scheduled runs: use main group
 concurrency:
-  # For PR-specific runs (comment or dispatch with PR number): use per-PR group
-  # For main/v4-draft branch runs: use branch-specific group
-  # For schedule: use main group
   group: |
     ${{
       (github.event_name == 'issue_comment' ||
@@ -39,11 +57,15 @@ concurrency:
     }}
   cancel-in-progress: true
 
+# ============================================================================
+# JOBS
+# ============================================================================
 jobs:
   check-comment:
-    # Run integration tests if:
-    # 1. Triggered by push to main/v4-draft, schedule, or workflow_dispatch, OR
-    # 2. Triggered by /integration-test comment on a PR from a user with write access
+    name: Run Integration Tests
+    # Authorization checks:
+    # - Always run: push, schedule, or manual workflow_dispatch
+    # - PR comment: only run "/integration-test" from OWNER, MEMBER, or COLLABORATOR
     if: |
       github.event_name != 'issue_comment' || (
         github.event.issue.pull_request != null &&
@@ -54,8 +76,13 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      # ====================================================================
+      # Step 1: Get PR metadata for PR-triggered runs
+      # ====================================================================
       - name: Get PR details
-        if: github.event_name == 'issue_comment' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '')
+        if: |
+          github.event_name == 'issue_comment' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '')
         id: pr_info
         uses: actions/github-script@v7
         with:
@@ -72,17 +99,40 @@ jobs:
             });
             core.setOutput('merge_commit_sha', pr.data.merge_commit_sha);
 
+      # ====================================================================
+      # Step 2: Checkout code
+      # ====================================================================
+      # For PR-triggered runs: check out the PR merge commit
+      # For branch runs: check out the pushed ref
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ (github.event_name == 'issue_comment' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '')) && steps.pr_info.outputs.merge_commit_sha || github.ref }}
+          ref: |
+            ${{
+              (github.event_name == 'issue_comment' ||
+               (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '')) &&
+              steps.pr_info.outputs.merge_commit_sha ||
+              github.ref
+            }}
 
+      # ====================================================================
+      # Step 3: Set up Go environment
+      # ====================================================================
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
           cache: true
 
+      # ====================================================================
+      # Step 4: Run integration tests with retry logic
+      # ====================================================================
+      # Tests are retried up to 3 times with 10-second delays between attempts.
+      # This helps mitigate transient API failures and network issues.
+      #
+      # Requirements:
+      # - HUGGING_FACE_TOKEN: GitHub secret with valid HuggingFace API token
+      # - Tests must be tagged with '//go:build integration'
       - name: Run live API integration tests (with retry)
         id: integration_tests
         env:
@@ -110,18 +160,30 @@ jobs:
           echo "All $max_attempts attempts failed"
           exit 1
 
+      # ====================================================================
+      # Step 5: Create/update failure issue (branch/schedule only)
+      # ====================================================================
+      # When tests fail on tracked branches or scheduled runs:
+      # - Creates a new GitHub issue (if none exists for this branch)
+      # - Adds a comment to existing issue with failure details
+      # - Uses branch-specific labels to track which branch is failing
+      # - Skipped for PR-triggered runs
       - name: Create or update issue on failure
-        if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
+        if: |
+          failure() &&
+          (github.event_name == 'push' || github.event_name == 'schedule')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const label = "integration-test-failure";
-            const title = "⚠️ Live API Integration Tests Failing";
+            const branchName = "${{ github.ref_name }}";
+            const label = `integration-test-failure:${branchName}`;
+            const title = `⚠️ Live API Integration Tests Failing (${branchName})`;
 
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const timestamp = new Date().toISOString();
 
+            // Search for existing open issues with the branch-specific failure label
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -132,16 +194,17 @@ jobs:
             const bodyUpdate = `### ❌ Failure detected at ${timestamp}\nRun: ${runUrl}`;
 
             if (issues.length === 0) {
+              // No existing issue found, create a new one with branch-specific label
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title,
                 labels: [label],
-                body: `Integration tests are currently failing.\n\n${bodyUpdate}`
+                body: `Integration tests are currently failing on the **${branchName}** branch.\n\n${bodyUpdate}`
               });
             } else {
+              // Issue exists, add a comment with the new failure details
               const issue = issues[0];
-
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -150,14 +213,26 @@ jobs:
               });
             }
 
+      # ====================================================================
+      # Step 6: Close failure issue on success (branch/schedule only)
+      # ====================================================================
+      # When tests pass after previous failures:
+      # - Adds a success comment to the issue
+      # - Closes the issue
+      # - Only closes issues for the specific branch that is now passing
+      # - Skipped for PR-triggered runs
       - name: Close issue on success
-        if: success() && (github.event_name == 'push' || github.event_name == 'schedule')
+        if: |
+          success() &&
+          (github.event_name == 'push' || github.event_name == 'schedule')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const label = "integration-test-failure";
+            const branchName = "${{ github.ref_name }}";
+            const label = `integration-test-failure:${branchName}`;
 
+            // Find all open issues with the branch-specific failure label
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -165,12 +240,13 @@ jobs:
               labels: label
             });
 
+            // Close each issue with a success comment
             for (const issue of issues) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: "### ✅ Integration tests are passing again. Closing issue."
+                body: "### ✅ Integration tests are passing again on the **" + branchName + "** branch. Closing issue."
               });
 
               await github.rest.issues.update({

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -71,9 +71,8 @@ jobs:
           echo "All $max_attempts attempts failed"
           exit 1
 
-      # FIXME: only create issues for scheduled runs, not for PRs
       - name: Create or update issue on failure
-        if: failure()
+        if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -112,9 +111,8 @@ jobs:
               });
             }
 
-      # FIXME: only close issues for scheduled runs, not for PRs
       - name: Close issue on success
-        if: success()
+        if: success() && (github.event_name == 'push' || github.event_name == 'schedule')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,46 +3,70 @@ name: Integration Tests
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches:
-      - main
-      - v4-draft
+    branches: [main, v4-draft]
   schedule:
     - cron: "35 21 * * 3"
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Optional: PR number to test"
+        required: false
+        type: number
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
   issues: write
+  pull-requests: read
 
 concurrency:
   group: integration-tests
   cancel-in-progress: true
 
 jobs:
-  integration-tests:
-    # Skip this job for PRs from forked repositories without access to secrets
-    # but allow it for PRs from branches within the main repository
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+  check-comment:
+    # Run integration tests if:
+    # 1. Triggered by push to main/v4-draft, schedule, or workflow_dispatch, OR
+    # 2. Triggered by /integration-test comment on a PR from a user with write access
+    if: |
+      github.event_name != 'issue_comment' || (
+        github.event.issue.pull_request != null &&
+        github.event.comment.body == '/integration-test' &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')
+      )
     runs-on: ubuntu-latest
-
     steps:
+      - name: Get PR details
+        if: github.event_name == 'issue_comment' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '')
+        id: pr_info
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = github.event_name == 'issue_comment'
+              ? github.event.issue.number
+              : github.event.inputs.pr_number;
+
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: parseInt(prNumber)
+            });
+            core.setOutput('merge_commit_sha', pr.data.merge_commit_sha);
+
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ (github.event_name == 'issue_comment' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '')) && steps.pr_info.outputs.merge_commit_sha || github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
           cache: true
-
-      - name: Validate required secrets
-        run: |
-          if [ -z "${{ secrets.HUGGING_FACE_TOKEN }}" ]; then
-            echo "::error::HUGGING_FACE_TOKEN secret is not set"
-            exit 1
-          fi
 
       - name: Run live API integration tests (with retry)
         id: integration_tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -90,9 +90,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = github.event_name == 'issue_comment'
-              ? github.event.issue.number
-              : github.event.inputs.pr_number;
+            const prNumber = context.eventName == 'issue_comment'
+              ? context.payload.issue.number
+              : context.payload.inputs.pr_number;
 
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
@@ -102,8 +102,7 @@ jobs:
 
             // Guard against null merge_commit_sha (PR not mergeable or merge not computed)
             if (!pr.data.merge_commit_sha) {
-              core.setFailed(`PR #${prNumber} is not mergeable or merge commit SHA is not available. Ensure the PR is mergeable before running tests.`);
-              process.exit(1);
+              throw new Error(`PR #${prNumber} is not mergeable or merge commit SHA is not available. Ensure the PR is mergeable before running tests.`);
             }
 
             core.setOutput('merge_commit_sha', pr.data.merge_commit_sha);

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # hfgo
 
+## ⚠️ Notice
+
+Pardon our dust!
+
+**v3** and earlier are significantly out of date from the upstream API.
+This project is currently undergoing a major overhaul, at the end of
+which **v4** will be released, the module will be renamed to `hfgo`,
+and **v3 will be deprecated**. See [#72](https://github.com/Kardbord/hfapigo/issues/72)
+for more information.
+
+---
+
 [![Unit Tests](https://github.com/Kardbord/hfgo/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/Kardbord/hfgo/actions/workflows/unit-tests.yml)
 [![CodeQL](https://github.com/Kardbord/hfgo/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/Kardbord/hfgo/actions/workflows/codeql-analysis.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Kardbord/hfgo)](https://goreportcard.com/report/github.com/Kardbord/hfgo)
@@ -9,14 +21,6 @@
 Directly call any model available in the [Model Hub](https://huggingface.co/models).
 
 An API key is required for authorized access. To get one, create a [Hugging Face](https://huggingface.co/) profile.
-
-## ⚠️ Notice
-
-**v3** and earlier are significantly out of date from the upstream API.
-This project is currently undergoing a major overhaul, at the end of
-which **v4** will be released, the module will be renamed to `hfgo`,
-and **v3 will be deprecated**. See [#72](https://github.com/Kardbord/hfapigo/issues/72)
-for more information.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Directly call any model available in the [Model Hub](https://huggingface.co/mode
 
 An API key is required for authorized access. To get one, create a [Hugging Face](https://huggingface.co/) profile.
 
+## ⚠️ Notice
+
+**v3** and earlier are significantly out of date from the upstream API.
+This project is currently undergoing a major overhaul, at the end of
+which **v4** will be released, the module will be renamed to `hfgo`,
+and **v3 will be deprecated**. See [#72](https://github.com/Kardbord/hfapigo/issues/72)
+for more information.
+
 ## Usage
 
 See the [examples](./examples) directory.
@@ -38,3 +46,4 @@ See the [examples](./examples) directory.
 - [HF on GitHub](https://github.com/huggingface)
   - Official [Python bindings](https://github.com/huggingface/huggingface_hub)
   - Official [JavaScript bindings](https://github.com/huggingface/huggingface.js)
+


### PR DESCRIPTION
Updates and fixes to the integration tests workflow:

- Only track issues for pushes to tracked branches and for scheduled runs
- Label issues more verbosely based on where the failure occurred
- Update triggers
    - No longer run automatically on PRs
    - Run on "/integration-test" comment by privileged user
    - Run on workflow dispatch
    - Run on push to main or v4-draft
- Update concurrency configuration to allow concurrent runs for different branches and PRs