### PR TITLE
ci: exclude link checker workflow from lychee scan

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -37,6 +37,7 @@ jobs:
             --max-cache-age 1d
             --verbose
             --no-progress
+            --exclude-path '(^|/)\.github/workflows/link-check\.yml$'
             --exclude '^https://router\.huggingface\.co/?$'
             './**/*.md'
             './**/*.html'


### PR DESCRIPTION
## Summary
- exclude `.github/workflows/link-check.yml` from lychee path scanning
- keep the existing URL exclusions and file globs unchanged

Fixes #93.

## Testing
- `git diff --check`
- parsed `.github/workflows/link-check.yml` with PyYAML and confirmed the lychee args are valid YAML content
- verified the exclude regex matches `.github/workflows/link-check.yml` and `./.github/workflows/link-check.yml`, but not unrelated files

AI disclosure: I used OpenAI Codex to help prepare this change.