### PR TITLE
fix(ci): avoid router link-check self-match

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -37,7 +37,7 @@ jobs:
             --max-cache-age 1d
             --verbose
             --no-progress
-            --exclude '^https://router\.huggingface\.co/?$'
+            --exclude '://router[.]huggingface[.]co/?$'
             './**/*.md'
             './**/*.html'
             './**/*.go'


### PR DESCRIPTION
﻿## Why

The link-check workflow reported a broken `https://router/` URL from `.github/workflows/link-check.yml`. That appears to come from the workflow scanning its own `--exclude '^https://router\.huggingface\.co/?$'` regex and treating the beginning of the regex as a URL.

Fixes #93.

## What Changed

Rewrote the exclude regex so it still matches `https://router.huggingface.co/`, but no longer contains a full `https://router...` URL literal that lychee can detect inside the workflow file.

## Verification

A local regex check confirms the new pattern matches both `https://router.huggingface.co` and `https://router.huggingface.co/`, and does not match unrelated hostnames.
