### PR TITLE
ci: Update integration tests trigger and workflow schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "05:00"
     commit-message:
       prefix: "fix(deps)"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "05:00"
     commit-message:
       prefix: "ci(deps)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - main
       - v4-draft
   schedule:
-    - cron: "35 21 * * 3"
+    - cron: "35 6 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@ on:
       - main
       - v4-draft
   schedule:
-    - cron: "35 21 * * 3"
+    - cron: "45 6 * * 1"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ on:
     types: [opened, synchronize, reopened]
 
   schedule:
-    - cron: "35 21 * * 3"
+    - cron: "5 6 * * 1"
 
 permissions:
   contents: read

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,7 +7,7 @@ on:
       - main
       - v4-draft
 
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
   schedule:
@@ -27,7 +27,7 @@ permissions:
 concurrency:
   group: |
     ${{
-      github.event_name == 'pull_request' &&
+      github.event_name == 'pull_request_target' &&
       format('integration-tests-pr-{0}', github.event.pull_request.number) ||
       format('integration-tests-{0}', github.ref_name)
     }}
@@ -41,7 +41,7 @@ jobs:
     # This controls costs by requiring a member/admin/owner to approve the run.
     # Push and schedule runs bypass the environment gate since they run on
     # protected branches that already require review before merge.
-    environment: ${{ github.event_name == 'pull_request' && 'integration-tests' || '' }}
+    environment: ${{ github.event_name == 'pull_request_target' && 'integration-tests' || '' }}
     permissions:
       contents: read
       id-token: write # Required for OIDC token to upload coverage and test results
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
       - main
       - v4-draft
   schedule:
-    - cron: "35 21 * * 3"
+    - cron: "25 6 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -5,7 +5,7 @@ on:
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
   branch_protection_rule:
   schedule:
-    - cron: "41 15 * * 6"
+    - cron: "55 6 * * 1"
   push:
     branches:
       - v4-draft

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ on:
       - main
       - v4-draft
   schedule:
-    - cron: "35 21 * * 3"
+    - cron: "15 6 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Change integration tests trigger to run on pull_request_target trigger so as to allow access to environment secrets for forked repositories and dependabot PRs. Update workflow schedules to run staggered early Monday mornings.