### PR TITLE
fix: Make checkout ref conditional for push/schedule events

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0


### PR DESCRIPTION
The checkout step was using github.event.pull_request.number for all event types, which is undefined for push and schedule events, causing git to fail with an invalid refspec error. 

This change makes the ref parameter conditional - it only uses the pull request merge ref for pull_request_target events, and leaves it empty for push and schedule events (allowing checkout to use the default branch).

Fixes the "fatal: invalid refspec '+refs/pull//merge:refs/remotes/pull//merge'" error.