### PR TITLE
ci: Group dependabot updates with common parents together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,10 @@ updates:
       time: "05:00"
     commit-message:
       prefix: "ci(deps)"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
+      cache:
+        patterns:
+          - "actions/cache/*"


### PR DESCRIPTION
Fix CI issues plaguing codeql-action updates by grouping all updates with a common parent module together.