### PR TITLE
ci: Fix incorrect release-please config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Run Release Please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          release-type: go
           config-file: ${{ steps.config.outputs.config-file }}
           manifest-file: ${{ steps.config.outputs.manifest-file }}
         env:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -62,6 +62,16 @@ required because the action's default manifest path is
 `.release-please-manifest.json` at the repository root, but this project
 stores both config and manifest files under `.github/`.
 
+> **Important:** The workflow must **not** pass the `release-type` action input.
+> `release-please-action` v5 treats a non-empty `release-type` input as the
+> "build from config" path, which **ignores** both the `config-file` and
+> `manifest-file` inputs and the configuration they contain (including
+> `versioning: prerelease`). It then falls back to default versioning derived
+> from existing git tags, which is what caused a draft branch to emit a stable
+> `v3.1.1` release instead of `v4.0.0-rc`. The `release-type` is instead
+> declared per-package in each config file. Omitting the `release-type` input
+> is what activates the `config-file`/`manifest-file` path.
+
 ### Why Separate Manifests?
 
 Each branch reads its own manifest file. This provides **structural version


### PR DESCRIPTION
Passing the `release-type` action input causes the build from config path for release-please, ignoring the config-file and manifest-file inputs. This is what caused an erroneous stable version bump in #127.