### PR TITLE
ci: Run build workflow on push to v4-draft

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,9 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - v4-draft
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Fix issue where the "build" workflows would not run on push to v4-draft.