### PR TITLE
ci: Fixed if-gate on validate-release-pr workflow

### DIFF
--- a/.github/workflows/validate-release-pr.yml
+++ b/.github/workflows/validate-release-pr.yml
@@ -3,7 +3,7 @@ name: Validate Release PR
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
 
 permissions:
   pull-requests: read
@@ -12,14 +12,32 @@ permissions:
 jobs:
   validate-release:
     # Only run on Release Please PRs (created by the release-please-action bot)
-    if: github.event.pull_request.user.login == 'release-please[bot]' && github.event.pull_request.user.type == 'Bot'
+    # 41898282 is the USER ID for the github-actions[bot] account
+    if: github.event.pull_request.user.id == 41898282 && github.event.pull_request.user.type == 'Bot'
     name: Validate go.mod for Release
     runs-on: ubuntu-latest
     steps:
+      # Runtime check of the PR's current labels (authoritative; the event
+      # payload's labels array can be empty on synchronize/opened events).
+      - name: Determine if release PR
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          LABELS="$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(",")')"
+          if [[ "$LABELS" == *"autorelease: pending"* ]]; then
+            echo "is-release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-release=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout code
+        if: steps.check.outputs.is-release == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Extract version and validate go.mod
+        if: steps.check.outputs.is-release == 'true'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |


### PR DESCRIPTION
The `validate-release-pr` workflow assumed that it would be the `release-please[bot]` user making the updates, but it is actually the `github-actions[bot]` user. These changes ensure release PR validation runs when appropriate by checking for the `autorelease: pending` label.