### PR TITLE
ci: Fix failing validate-release-pr workflow; add --repo flag

### DIFF
--- a/.github/workflows/validate-release-pr.yml
+++ b/.github/workflows/validate-release-pr.yml
@@ -24,8 +24,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          LABELS="$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(",")')"
+          LABELS="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")')"
           if [[ "$LABELS" == *"autorelease: pending"* ]]; then
             echo "is-release=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
Fix the failure in validate-release-pr workflow caused by `gh` not having a repo to work with.