### PR TITLE
ci: Fix validate-release-pr regex and exempt release-please PRs from API diff gate

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -40,12 +40,40 @@ jobs:
       - name: Check for breaking API changes
         id: apidiff
         uses: joelanford/go-apidiff@60c4206be8f84348ebda2a3e0c3ac9cb54b8f685 # v0.8.3
+        # go-apidiff exits non-zero when it detects a breaking (major) change.
+        # Absorb that so the job continues and the next step decides the outcome.
+        continue-on-error: true
+
+      # Determine if this is a Release Please PR. We read labels at runtime
+      # because the event payload's labels array can be empty on opened/synchronize.
+      # Release PRs (autorelease: pending) are exempt from the breaking-change gate:
+      # their version is already derived by release-please from properly-marked commits,
+      # and re-checking API diffs against rc bumps would otherwise cause false failures.
+      - name: Determine if release PR
+        id: is-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          LABELS="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")')"
+          if [[ "$LABELS" == *"autorelease: pending"* ]]; then
+            echo "is-release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-release=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Validate breaking change marking
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          IS_RELEASE: ${{ steps.is-release.outputs.is-release }}
           SEMVER_TYPE: ${{ steps.apidiff.outputs.semver-type }}
         run: |
+          if [[ "$IS_RELEASE" == "true" ]]; then
+            echo "⏭️ Skipping breaking-change validation for release-please PR"
+            exit 0
+          fi
+
           TITLE="$PR_TITLE"
           BREAKING_REGEX='^[a-z]+(\([^)]+\))?!:'
           if [[ "$TITLE" =~ $BREAKING_REGEX ]]; then

--- a/.github/workflows/validate-release-pr.yml
+++ b/.github/workflows/validate-release-pr.yml
@@ -43,7 +43,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Release Please PR title format: "chore(main): release v4.1.0"
-          VERSION=$(echo "$PR_TITLE" | grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+          VERSION=$(echo "$PR_TITLE" | grep -oP 'v?\K[0-9]+\.[0-9]+\.[0-9]+' || echo "")
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
 
           if [[ -z "$VERSION" ]]; then


### PR DESCRIPTION
* [fix validate-release-pr regex](https://github.com/Kardbord/hfapigo/commit/4c3532116c20634db5b37dd2381972b59d52758b)
* [ci: exempt release-please PRs from API diff gate](https://github.com/Kardbord/hfapigo/commit/fffd13b0c097db995f0cde4fa10a95868ba5d764)