### PR TITLE
ci: reliability + DRY refactor

### DIFF
--- a/.github/actions/checkout-pr-merge/action.yml
+++ b/.github/actions/checkout-pr-merge/action.yml
@@ -1,0 +1,51 @@
+---
+name: Checkout PR merge
+description: >
+  Check out a branch and, when given a PR number, reconstruct the PR merge
+  commit deterministically instead of relying on the lazily-published
+  refs/pull/N/merge ref.
+inputs:
+  ref:
+    description: >
+      Ref to check out. For pull_request_target runs this is the PR's base
+      branch; for push/schedule/workflow_dispatch it is the pushed branch.
+    required: true
+  pr-number:
+    description: >
+      PR number. When non-empty, fetch refs/pull/N/head and merge it into the
+      checked-out base to reconstruct the merge commit. Leave empty on
+      non-PR events.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Checkout branch
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ inputs.ref }}
+        # Full history is required so the merge below can compute a merge base.
+        fetch-depth: 0
+
+    # The merge ref (refs/pull/N/merge) is lazily published by GitHub and can
+    # be missing when a pull_request_target run starts, causing transient
+    # "couldn't find remote ref" failures (and, in pr-title-check, letting a
+    # broken checkout silently bypass the breaking-change gate). Reconstruct
+    # the merge commit reliably from the base branch and the always-available
+    # refs/pull/N/head instead. Merging head into base reproduces the merge
+    # GitHub computes for refs/pull/N/merge (base = first parent, head =
+    # second) with the same resulting tree; only the commit hash differs
+    # (GitHub's own committer/timestamp), which is irrelevant for CI. If the
+    # base branch advances between event delivery and this fetch, the tree
+    # reflects the newer base (what a fresh merge would use), so it can differ
+    # slightly from the event-time merge ref. A conflicting PR fails loudly
+    # here, mirroring GitHub, which also cannot produce a merge ref for a
+    # conflicted PR.
+    - name: Reconstruct PR merge commit
+      if: inputs.pr-number != ''
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git fetch origin "refs/pull/${{ inputs.pr-number }}/head"
+        git merge --no-ff --no-edit FETCH_HEAD

--- a/.github/actions/is-release-pr/action.yml
+++ b/.github/actions/is-release-pr/action.yml
@@ -1,0 +1,31 @@
+---
+name: Determine if release PR
+description: >
+  Check at runtime whether a pull request is a release-please PR by inspecting
+  its current labels for the 'autorelease: pending' label (authoritative; the
+  event payload's labels array can be empty on opened/synchronize).
+inputs:
+  pr-number:
+    description: Pull request number to inspect.
+    required: true
+outputs:
+  is-release:
+    description: "'true' if the PR carries the autorelease: pending label, else 'false'."
+    value: ${{ steps.check.outputs.is-release }}
+runs:
+  using: composite
+  steps:
+    - name: Determine if release PR
+      id: check
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+      shell: bash
+      run: |
+        LABELS="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")')"
+        if [[ "$LABELS" == *"autorelease: pending"* ]]; then
+          echo "is-release=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "is-release=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/parse-model/action.yml
+++ b/.github/actions/parse-model/action.yml
@@ -1,0 +1,47 @@
+---
+name: Parse model from comment
+description: >
+  Resolve an opencode model from a comment body against an allowlist, falling
+  back to a default when none is requested or the requested model is not
+  allowed. Centralizes the allowlist so it is maintained in one place.
+inputs:
+  body:
+    description: The comment body to parse.
+    required: true
+outputs:
+  model:
+    description: The resolved model (requested allowed model, or the default).
+    value: ${{ steps.resolve.outputs.model }}
+runs:
+  using: composite
+  steps:
+    - name: Resolve model
+      id: resolve
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      with:
+        script: |
+          const ALLOWED_MODELS = [
+            'openrouter/openrouter/free',
+            'openrouter/openrouter/auto',
+            'openrouter/deepseek/deepseek-v4-pro',
+            'openrouter/~deepseek/deepseek-v4-flash-latest',
+            'openrouter/moonshotai/kimi-k2.6',
+            'openrouter/qwen/qwen3.6-flash',
+            'openrouter/mistralai/devstral-2512',
+            'openrouter/google/gemini-3.5-flash',
+            'openrouter/google/gemma-4-31b-it',
+            'openrouter/z-ai/glm-5.1',
+            'openrouter/xiaomi/mimo-v2.5',
+            'openrouter/minimax/minimax-m2.7',
+            'openrouter/ibm-granite/granite-4.1-8b',
+            'openrouter/kwaipilot/kat-coder-pro-v2',
+            'openrouter/inclusionai/ring-2.6-1t',
+            'openrouter/inception/mercury-2',
+            'openrouter/anthropic/claude-haiku-4.5',
+            'openrouter/anthropic/claude-sonnet-4.6'
+          ];
+          const DEFAULT_MODEL = 'openrouter/~deepseek/deepseek-v4-flash-latest';
+          const body = core.getInput('body');
+          const match = body.match(/model=(\S+)/);
+          const requested = match ? match[1] : '';
+          core.setOutput('model', ALLOWED_MODELS.includes(requested) ? requested : DEFAULT_MODEL);

--- a/.github/actions/parse-model/action.yml
+++ b/.github/actions/parse-model/action.yml
@@ -19,6 +19,10 @@ runs:
       id: resolve
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
+        # The body must be passed into the github-script step so core.getInput
+        # below can read it; a composite's input is not visible to nested actions
+        # unless propagated via with:/env.
+        body: ${{ inputs.body }}
         script: |
           const ALLOWED_MODELS = [
             'openrouter/openrouter/free',

--- a/.github/actions/parse-model/action.yml
+++ b/.github/actions/parse-model/action.yml
@@ -46,6 +46,6 @@ runs:
           ];
           const DEFAULT_MODEL = 'openrouter/~deepseek/deepseek-v4-flash-latest';
           const body = process.env.BODY || '';
-          const match = body.match(/model=(\S+)/);
+          const match = body.match(/^\/(?:review|opencode|oc)\s+model=(\S+)/);
           const requested = match ? match[1] : '';
           core.setOutput('model', ALLOWED_MODELS.includes(requested) ? requested : DEFAULT_MODEL);

--- a/.github/actions/parse-model/action.yml
+++ b/.github/actions/parse-model/action.yml
@@ -18,11 +18,11 @@ runs:
     - name: Resolve model
       id: resolve
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        # A composite action's input is not visible to nested actions unless
+        # propagated via with:/env; pass the body through explicitly via env.
+        BODY: ${{ inputs.body }}
       with:
-        # The body must be passed into the github-script step so core.getInput
-        # below can read it; a composite's input is not visible to nested actions
-        # unless propagated via with:/env.
-        body: ${{ inputs.body }}
         script: |
           const ALLOWED_MODELS = [
             'openrouter/openrouter/free',
@@ -45,7 +45,7 @@ runs:
             'openrouter/anthropic/claude-sonnet-4.6'
           ];
           const DEFAULT_MODEL = 'openrouter/~deepseek/deepseek-v4-flash-latest';
-          const body = core.getInput('body');
+          const body = process.env.BODY || '';
           const match = body.match(/model=(\S+)/);
           const requested = match ? match[1] : '';
           core.setOutput('model', ALLOWED_MODELS.includes(requested) ? requested : DEFAULT_MODEL);

--- a/.github/actions/require-job-passed/action.yml
+++ b/.github/actions/require-job-passed/action.yml
@@ -1,0 +1,24 @@
+---
+name: Require job passed
+description: >
+  Fail the containing job unless a referenced prerequisite job passed. Converts
+  a prerequisite that failed or was cancelled into a loud, blocking signal,
+  instead of silently passing when that prerequisite's outputs are unset.
+inputs:
+  result:
+    description: >
+      The prerequisite job's result (e.g. needs.<job>.result). Fails when this
+      is 'failure' or 'cancelled'.
+    required: true
+  message:
+    description: Message printed when the step fails.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Fail unless prerequisite job passed
+      if: inputs.result == 'failure' || inputs.result == 'cancelled'
+      shell: bash
+      run: |
+        printf '%s\n' "${{ inputs.message }}"
+        exit 1

--- a/.github/actions/run-opencode/action.yml
+++ b/.github/actions/run-opencode/action.yml
@@ -1,0 +1,39 @@
+---
+name: Run OpenCode
+description: >
+  Check out the repository (without persisting credentials) and run the OpenCode
+  GitHub action. Centralizes the pinned opencode action, the OPENROUTER_API_KEY
+  wiring, and the checkout configuration so they are maintained in one place.
+inputs:
+  model:
+    description: Model to run OpenCode with.
+    required: true
+  prompt:
+    description: Optional prompt to pass to OpenCode.
+    required: false
+    default: ""
+  agent:
+    description: Optional OpenCode agent to use.
+    required: false
+    default: ""
+  share:
+    description: Whether to share the OpenCode session.
+    required: false
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Run OpenCode
+      uses: anomalyco/opencode/github@7902e04c3a67f7c69726bc955efb46e29214c797 # v1.18.10
+      env:
+        OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      with:
+        model: ${{ inputs.model }}
+        share: ${{ inputs.share }}
+        agent: ${{ inputs.agent }}
+        prompt: ${{ inputs.prompt }}

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,24 @@
+---
+name: Set up Go
+description: >
+  Install the Go toolchain from go.mod with module cache, and optionally install
+  gotestsum. Centralizes the pinned actions/setup-go and gotestsum versions used
+  across workflows.
+inputs:
+  install-gotestsum:
+    description: Whether to also install gotestsum ('true' or 'false').
+    required: false
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - name: Install Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        cache: true
+        go-version-file: go.mod
+
+    - name: Install gotestsum
+      if: inputs.install-gotestsum == 'true'
+      shell: bash
+      run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f # v1.13.0

--- a/.github/actions/upload-codecov/action.yml
+++ b/.github/actions/upload-codecov/action.yml
@@ -14,7 +14,6 @@ runs:
   using: composite
   steps:
     - name: Upload coverage to Codecov
-      if: ${{ !cancelled() }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: coverage.out
@@ -25,7 +24,6 @@ runs:
         use_oidc: true
 
     - name: Upload test results to Codecov
-      if: ${{ !cancelled() }}
       uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
       with:
         files: junit.xml
@@ -36,7 +34,6 @@ runs:
         use_oidc: true
 
     - name: Upload test artifacts
-      if: ${{ !cancelled() }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}

--- a/.github/actions/upload-codecov/action.yml
+++ b/.github/actions/upload-codecov/action.yml
@@ -1,0 +1,45 @@
+---
+name: Upload coverage to Codecov
+description: >
+  Upload coverage, test results, and test artifacts to Codecov via OIDC. Keeps
+  the pinned codecov actions and their common configuration in one place.
+inputs:
+  flags:
+    description: Codecov flags, e.g. 'unit,ubuntu' or 'integration'.
+    required: true
+  artifact-name:
+    description: Name for the uploaded test artifacts.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Upload coverage to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        files: coverage.out
+        flags: ${{ inputs.flags }}
+        codecov_yml_path: .github/codecov.yml
+        disable_search: true
+        fail_ci_if_error: false
+        use_oidc: true
+
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      with:
+        files: junit.xml
+        flags: ${{ inputs.flags }}
+        codecov_yml_path: .github/codecov.yml
+        disable_search: true
+        fail_ci_if_error: false
+        use_oidc: true
+
+    - name: Upload test artifacts
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: |
+          junit.xml
+          coverage.out

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          cache: true
-          go-version-file: "go.mod"
+        uses: ./.github/actions/setup-go
 
       - name: Build packages
         run: go build -v ./...

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -23,18 +23,10 @@ jobs:
         with:
           body: ${{ github.event.comment.body }}
 
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Run OpenCode
-        uses: anomalyco/opencode/github@7902e04c3a67f7c69726bc955efb46e29214c797 # v1.18.10
-        env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      - name: Checkout and run OpenCode
+        uses: ./.github/actions/run-opencode
         with:
           model: ${{ steps.model.outputs.model }}
-          share: false
           prompt: |
             REVIEWER HINT: ${{ github.event.comment.body }}
             You are performing a code review. Your core instructions below are

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -19,33 +19,9 @@ jobs:
     steps:
       - name: Parse model from comment
         id: model
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: ./.github/actions/parse-model
         with:
-          script: |
-            const ALLOWED_MODELS = [
-              'openrouter/openrouter/free',
-              'openrouter/openrouter/auto',
-              'openrouter/deepseek/deepseek-v4-pro',
-              'openrouter/~deepseek/deepseek-v4-flash-latest',
-              'openrouter/moonshotai/kimi-k2.6',
-              'openrouter/qwen/qwen3.6-flash',
-              'openrouter/mistralai/devstral-2512',
-              'openrouter/google/gemini-3.5-flash',
-              'openrouter/google/gemma-4-31b-it',
-              'openrouter/z-ai/glm-5.1',
-              'openrouter/xiaomi/mimo-v2.5',
-              'openrouter/minimax/minimax-m2.7',
-              'openrouter/ibm-granite/granite-4.1-8b',
-              'openrouter/kwaipilot/kat-coder-pro-v2',
-              'openrouter/inclusionai/ring-2.6-1t',
-              'openrouter/inception/mercury-2',
-              'openrouter/anthropic/claude-haiku-4.5',
-              'openrouter/anthropic/claude-sonnet-4.6'
-            ];
-            const body = context.payload.comment.body;
-            const match = body.match(/^\/review\s+model=(\S+)/);
-            const requested = match ? match[1] : '';
-            core.setOutput('model', ALLOWED_MODELS.includes(requested) ? requested : 'openrouter/~deepseek/deepseek-v4-flash-latest');
+          body: ${{ github.event.comment.body }}
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,10 +32,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          cache: true
-          go-version-file: "go.mod"
+        uses: ./.github/actions/setup-go
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,23 +47,26 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       run_tests: ${{ steps.check_changes.outputs.run_tests }}
     steps:
-      - name: Checkout and reconstruct PR merge
-        uses: ./.github/actions/checkout-pr-merge
-        with:
-          ref: ${{ github.event.pull_request.base.ref || github.ref }}
-          pr-number: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || '' }}
-
       - name: Check for code changes
         id: check_changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [[ "${{ github.event_name }}" != "pull_request_target" ]]; then
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          CHANGED_FILES=$(git diff --name-only HEAD^1 HEAD)
+          # Fetch changed files from the API rather than checking out and
+          # merging the PR head: this job is ungated (runs before environment
+          # approval), so untrusted fork code must never be materialized here.
+          # A failure surfaces loudly (no || true) and is caught by the
+          # integration-tests aggregator rather than silently skipping.
+          CHANGED_FILES="$(gh pr view "$PR_NUMBER" --json files --jq '.files[].filename')"
           echo "Changed files:"
           echo "$CHANGED_FILES"
           CODE_CHANGES=$(echo "$CHANGED_FILES" | grep -v '^docs/' | grep -v '\.md$' | grep -v '^LICENSE$' | grep -v '^\.github/' || true)

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,11 +50,23 @@ jobs:
     outputs:
       run_tests: ${{ steps.check_changes.outputs.run_tests }}
     steps:
-      - name: Checkout code
+      - name: Checkout base
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
-          fetch-depth: 2
+          ref: ${{ github.event.pull_request.base.ref || github.ref }}
+          fetch-depth: 0
+
+      # The merge ref (refs/pull/N/merge) is lazily published by GitHub and can
+      # be missing when a pull_request_target run starts, causing transient
+      # "couldn't find remote ref" failures. Reconstruct the merge commit
+      # deterministically from the base branch and the always-available PR head.
+      - name: Reconstruct PR merge commit
+        if: github.event_name == 'pull_request_target'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "refs/pull/${{ github.event.pull_request.number }}/head"
+          git merge --no-ff --no-edit FETCH_HEAD
 
       - name: Check for code changes
         id: check_changes
@@ -94,10 +106,21 @@ jobs:
       id-token: write # Required for OIDC token to upload coverage and test results
       issues: write # For creating/closing failure issues
     steps:
-      - name: Checkout code
+      - name: Checkout base
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+          ref: ${{ github.event.pull_request.base.ref || github.ref }}
+          fetch-depth: 0
+
+      # See check-changes: reconstruct the merge commit deterministically
+      # instead of relying on the lazily-published refs/pull/N/merge ref.
+      - name: Reconstruct PR merge commit
+        if: github.event_name == 'pull_request_target'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "refs/pull/${{ github.event.pull_request.number }}/head"
+          git merge --no-ff --no-edit FETCH_HEAD
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -104,13 +104,9 @@ jobs:
           pr-number: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || '' }}
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
-          cache: true
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f # v1.13.0
+          install-gotestsum: 'true'
 
       # Tests are retried up to 3 times with 10-second delays between attempts.
       # This helps mitigate transient API failures and network issues.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,7 +66,7 @@ jobs:
           # approval), so untrusted fork code must never be materialized here.
           # A failure surfaces loudly (no || true) and is caught by the
           # integration-tests aggregator rather than silently skipping.
-          CHANGED_FILES="$(gh pr view "$PR_NUMBER" --json files --jq '.files[].filename')"
+          CHANGED_FILES="$(gh api --paginate "repos/{owner}/{repo}/pulls/$PR_NUMBER/files" --jq '.[].filename')"
           echo "Changed files:"
           echo "$CHANGED_FILES"
           CODE_CHANGES=$(echo "$CHANGED_FILES" | grep -v '^docs/' | grep -v '\.md$' | grep -v '^LICENSE$' | grep -v '^\.github/' || true)
@@ -132,6 +132,7 @@ jobs:
             -covermode=atomic
 
       - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/upload-codecov
         with:
           flags: integration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,11 +60,15 @@ jobs:
       # be missing when a pull_request_target run starts, causing transient
       # "couldn't find remote ref" failures. Reconstruct the merge commit
       # reliably from the base branch and the always-available PR head.
-      # Merging head into base reproduces GitHub's merge ref (base = first
-      # parent, head = second) with a byte-identical tree; only the commit hash
-      # differs (GitHub's own committer/timestamp), which is irrelevant for CI.
-      # A conflicting PR fails loudly here, mirroring GitHub, which also cannot
-      # produce a merge ref for a conflicted PR.
+      # Merging head into base reproduces the merge GitHub computes for
+      # refs/pull/N/merge (base = first parent, head = second) with the same
+      # resulting tree; only the commit hash differs (GitHub's own
+      # committer/timestamp), which is irrelevant for CI. If the base branch
+      # advances between event delivery and this fetch, the tree reflects the
+      # newer base (what a fresh merge would use), so it can differ slightly
+      # from the event-time merge ref. A conflicting PR fails loudly here,
+      # mirroring GitHub, which also cannot produce a merge ref for a conflicted
+      # PR.
       - name: Reconstruct PR merge commit
         if: github.event_name == 'pull_request_target'
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -59,7 +59,12 @@ jobs:
       # The merge ref (refs/pull/N/merge) is lazily published by GitHub and can
       # be missing when a pull_request_target run starts, causing transient
       # "couldn't find remote ref" failures. Reconstruct the merge commit
-      # deterministically from the base branch and the always-available PR head.
+      # reliably from the base branch and the always-available PR head.
+      # Merging head into base reproduces GitHub's merge ref (base = first
+      # parent, head = second) with a byte-identical tree; only the commit hash
+      # differs (GitHub's own committer/timestamp), which is irrelevant for CI.
+      # A conflicting PR fails loudly here, mirroring GitHub, which also cannot
+      # produce a merge ref for a conflicted PR.
       - name: Reconstruct PR merge commit
         if: github.event_name == 'pull_request_target'
         run: |
@@ -112,8 +117,8 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref || github.ref }}
           fetch-depth: 0
 
-      # See check-changes: reconstruct the merge commit deterministically
-      # instead of relying on the lazily-published refs/pull/N/merge ref.
+      # Reconstruct the merge commit reliably instead of relying on the
+      # lazily-published refs/pull/N/merge ref. See check-changes for details.
       - name: Reconstruct PR merge commit
         if: github.event_name == 'pull_request_target'
         run: |
@@ -321,8 +326,13 @@ jobs:
       - name: Check integration test results
         run: |
           result="${{ needs.run-integration-tests.result }}"
-          if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
-            echo "Integration tests failed (result: $result)."
+          check_changes_result="${{ needs.check-changes.result }}"
+          # Fail not only when the test job failed, but also when check-changes
+          # crashed: in that case run_tests is unset, run-integration-tests is
+          # skipped, and this job would otherwise report a silent pass, hiding a
+          # missing integration-test signal.
+          if [[ "$result" == "failure" || "$result" == "cancelled" || "$check_changes_result" == "failure" || "$check_changes_result" == "cancelled" ]]; then
+            echo "Integration test job failed or its check-changes prerequisite failed (result: $result, check-changes: $check_changes_result)."
             exit 1
           fi
-          echo "Integration tests passed or were skipped (result: $result)."
+          echo "Integration tests passed or were skipped (result: $result, check-changes: $check_changes_result)."

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,32 +50,11 @@ jobs:
     outputs:
       run_tests: ${{ steps.check_changes.outputs.run_tests }}
     steps:
-      - name: Checkout base
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout and reconstruct PR merge
+        uses: ./.github/actions/checkout-pr-merge
         with:
           ref: ${{ github.event.pull_request.base.ref || github.ref }}
-          fetch-depth: 0
-
-      # The merge ref (refs/pull/N/merge) is lazily published by GitHub and can
-      # be missing when a pull_request_target run starts, causing transient
-      # "couldn't find remote ref" failures. Reconstruct the merge commit
-      # reliably from the base branch and the always-available PR head.
-      # Merging head into base reproduces the merge GitHub computes for
-      # refs/pull/N/merge (base = first parent, head = second) with the same
-      # resulting tree; only the commit hash differs (GitHub's own
-      # committer/timestamp), which is irrelevant for CI. If the base branch
-      # advances between event delivery and this fetch, the tree reflects the
-      # newer base (what a fresh merge would use), so it can differ slightly
-      # from the event-time merge ref. A conflicting PR fails loudly here,
-      # mirroring GitHub, which also cannot produce a merge ref for a conflicted
-      # PR.
-      - name: Reconstruct PR merge commit
-        if: github.event_name == 'pull_request_target'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin "refs/pull/${{ github.event.pull_request.number }}/head"
-          git merge --no-ff --no-edit FETCH_HEAD
+          pr-number: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || '' }}
 
       - name: Check for code changes
         id: check_changes
@@ -115,21 +94,11 @@ jobs:
       id-token: write # Required for OIDC token to upload coverage and test results
       issues: write # For creating/closing failure issues
     steps:
-      - name: Checkout base
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout and reconstruct PR merge
+        uses: ./.github/actions/checkout-pr-merge
         with:
           ref: ${{ github.event.pull_request.base.ref || github.ref }}
-          fetch-depth: 0
-
-      # Reconstruct the merge commit reliably instead of relying on the
-      # lazily-published refs/pull/N/merge ref. See check-changes for details.
-      - name: Reconstruct PR merge commit
-        if: github.event_name == 'pull_request_target'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin "refs/pull/${{ github.event.pull_request.number }}/head"
-          git merge --no-ff --no-edit FETCH_HEAD
+          pr-number: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || '' }}
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -132,35 +132,10 @@ jobs:
             -covermode=atomic
 
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        uses: ./.github/actions/upload-codecov
         with:
-          files: coverage.out
           flags: integration
-          codecov_yml_path: .github/codecov.yml
-          disable_search: true
-          fail_ci_if_error: false
-          use_oidc: true
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          files: junit.xml
-          flags: integration
-          codecov_yml_path: .github/codecov.yml
-          disable_search: true
-          fail_ci_if_error: false
-          use_oidc: true
-
-      - name: Upload test artifacts
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: integration-test-results
-          path: |
-            junit.xml
-            coverage.out
+          artifact-name: integration-test-results
 
       # Creates branch-specific labels if they don't already exist.
       # This ensures that the subsequent issue creation/update steps can use these labels.

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -31,21 +31,12 @@ jobs:
             }
             core.setOutput('allowed', allowed);
 
-      - name: Checkout code
+      - name: Checkout and run OpenCode
         if: steps.account.outputs.allowed == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Run OpenCode
-        if: steps.account.outputs.allowed == 'true'
-        uses: anomalyco/opencode/github@7902e04c3a67f7c69726bc955efb46e29214c797 # v1.18.10
-        env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        uses: ./.github/actions/run-opencode
         with:
           model: openrouter/~deepseek/deepseek-v4-flash-latest
           agent: plan
-          share: false
           prompt: |
             You are performing issue triage. You MUST follow these rules strictly:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,10 +26,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          cache: true
-          go-version-file: "go.mod"
+        uses: ./.github/actions/setup-go
 
       - name: Vet
         run: go vet -v ./...

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -26,15 +26,7 @@ jobs:
         with:
           body: ${{ github.event.comment.body }}
 
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Run OpenCode
-        uses: anomalyco/opencode/github@7902e04c3a67f7c69726bc955efb46e29214c797 # v1.18.10
-        env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      - name: Checkout and run OpenCode
+        uses: ./.github/actions/run-opencode
         with:
           model: ${{ steps.model.outputs.model }}
-          share: false

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -22,33 +22,9 @@ jobs:
     steps:
       - name: Parse model from comment
         id: model
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: ./.github/actions/parse-model
         with:
-          script: |
-            const ALLOWED_MODELS = [
-              'openrouter/openrouter/free',
-              'openrouter/openrouter/auto',
-              'openrouter/deepseek/deepseek-v4-pro',
-              'openrouter/~deepseek/deepseek-v4-flash-latest',
-              'openrouter/moonshotai/kimi-k2.6',
-              'openrouter/qwen/qwen3.6-flash',
-              'openrouter/mistralai/devstral-2512',
-              'openrouter/google/gemini-3.5-flash',
-              'openrouter/google/gemma-4-31b-it',
-              'openrouter/z-ai/glm-5.1',
-              'openrouter/xiaomi/mimo-v2.5',
-              'openrouter/minimax/minimax-m2.7',
-              'openrouter/ibm-granite/granite-4.1-8b',
-              'openrouter/kwaipilot/kat-coder-pro-v2',
-              'openrouter/inclusionai/ring-2.6-1t',
-              'openrouter/inception/mercury-2',
-              'openrouter/anthropic/claude-haiku-4.5',
-              'openrouter/anthropic/claude-sonnet-4.6'
-            ];
-            const body = context.payload.comment.body;
-            const match = body.match(/^\/(?:opencode|oc)\s+model=(\S+)/);
-            const requested = match ? match[1] : '';
-            core.setOutput('model', ALLOWED_MODELS.includes(requested) ? requested : 'openrouter/~deepseek/deepseek-v4-flash-latest');
+          body: ${{ github.event.comment.body }}
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -98,9 +98,21 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           IS_RELEASE: ${{ steps.is-release.outputs.is-release }}
           SEMVER_TYPE: ${{ steps.apidiff.outputs.semver-type }}
+          APIDIFF_OUTCOME: ${{ steps.apidiff.outcome }}
         run: |
           if [[ "$IS_RELEASE" == "true" ]]; then
             echo "⏭️ Skipping breaking-change validation for release-please PR"
+            exit 0
+          fi
+
+          # go-apidiff uses a non-zero exit to signal a detected breaking change,
+          # which continue-on-error absorbs, so a step failure doesn't distinguish
+          # detection from a crash. If it failed without reporting a semver
+          # verdict, the check is inconclusive: block loudly instead of silently
+          # letting an unmarked breaking change slip through.
+          if [[ "$APIDIFF_OUTCOME" == "failure" && -z "$SEMVER_TYPE" ]]; then
+            echo "reason=API diff check could not complete (go-apidiff failed without a semver verdict). Re-run the workflow." >> "$GITHUB_OUTPUT"
+            echo "❌ API diff check could not complete (go-apidiff failed without a semver verdict). Re-run the workflow."
             exit 0
           fi
 

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -49,11 +49,15 @@ jobs:
       # be missing when a pull_request_target run starts. If checkout of that
       # ref fails, go-apidiff below never runs and the breaking-change gate
       # silently passes. Reconstruct the merge commit reliably instead.
-      # Merging head into base reproduces GitHub's merge ref (base = first
-      # parent, head = second) with a byte-identical tree; only the commit hash
-      # differs (GitHub's own committer/timestamp), which is irrelevant for CI.
-      # A conflicting PR fails loudly here, mirroring GitHub, which also cannot
-      # produce a merge ref for a conflicted PR.
+      # Merging head into base reproduces the merge GitHub computes for
+      # refs/pull/N/merge (base = first parent, head = second) with the same
+      # resulting tree; only the commit hash differs (GitHub's own
+      # committer/timestamp), which is irrelevant for CI. If the base branch
+      # advances between event delivery and this fetch, the tree reflects the
+      # newer base (what a fresh merge would use), so it can differ slightly
+      # from the event-time merge ref. A conflicting PR fails loudly here,
+      # mirroring GitHub, which also cannot produce a merge ref for a conflicted
+      # PR.
       - name: Reconstruct PR merge commit
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -39,11 +39,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout code
+      - name: Checkout base
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
+          ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
+
+      # The merge ref (refs/pull/N/merge) is lazily published by GitHub and can
+      # be missing when a pull_request_target run starts. If checkout of that
+      # ref fails, go-apidiff below never runs and the breaking-change gate
+      # silently passes. Reconstruct the merge commit deterministically instead.
+      - name: Reconstruct PR merge commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "refs/pull/${{ github.event.pull_request.number }}/head"
+          git merge --no-ff --no-edit FETCH_HEAD
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       title-error: ${{ steps.lint-pr-title.outputs.error_message }}
       breaking-reason: ${{ steps.breaking-change.outputs.reason }}
+      breaking-state: ${{ steps.breaking-change.outputs.state }}
     steps:
       - name: Validate PR title format
         id: lint-pr-title
@@ -85,6 +86,7 @@ jobs:
           # verdict, the check is inconclusive: block loudly instead of silently
           # letting an unmarked breaking change slip through.
           if [[ "$APIDIFF_OUTCOME" == "failure" && -z "$SEMVER_TYPE" ]]; then
+            echo "state=inconclusive" >> "$GITHUB_OUTPUT"
             echo "reason=API diff check could not complete (go-apidiff failed without a semver verdict). Re-run the workflow." >> "$GITHUB_OUTPUT"
             echo "❌ API diff check could not complete (go-apidiff failed without a semver verdict). Re-run the workflow."
             exit 0
@@ -110,10 +112,12 @@ jobs:
           echo ""
 
           if [[ "$API_HAS_BREAKING" == "true" ]] && [[ "$HAS_BREAKING_MARKER" != "true" ]]; then
+            echo "state=breaking" >> "$GITHUB_OUTPUT"
             echo "reason=Breaking API changes detected but PR title not marked with '!'. Example: feat!: remove deprecated method" >> "$GITHUB_OUTPUT"
             echo "❌ Breaking API changes detected but PR title not marked with '!'"
             echo "Example: feat!: remove deprecated method"
           else
+            echo "state=ok" >> "$GITHUB_OUTPUT"
             echo "✅ Breaking change marking is correct"
           fi
 
@@ -174,7 +178,7 @@ jobs:
         run: printf '%s' "$BREAKING_REASON" > "$RUNNER_TEMP/breaking-reason.md"
 
       - name: Comment on PR breaking change marker
-        if: always() && (needs.validate.outputs.breaking-reason != '')
+        if: always() && needs.validate.outputs.breaking-state == 'breaking'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: pr-breaking-change
@@ -194,7 +198,7 @@ jobs:
             ```
 
       - name: Resolve PR breaking change comment
-        if: always() && (needs.validate.outputs.breaking-reason == '')
+        if: always() && needs.validate.outputs.breaking-state != 'breaking'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: pr-breaking-change

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -39,31 +39,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout base
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout and reconstruct PR merge
+        uses: ./.github/actions/checkout-pr-merge
         with:
           ref: ${{ github.event.pull_request.base.ref }}
-          fetch-depth: 0
-
-      # The merge ref (refs/pull/N/merge) is lazily published by GitHub and can
-      # be missing when a pull_request_target run starts. If checkout of that
-      # ref fails, go-apidiff below never runs and the breaking-change gate
-      # silently passes. Reconstruct the merge commit reliably instead.
-      # Merging head into base reproduces the merge GitHub computes for
-      # refs/pull/N/merge (base = first parent, head = second) with the same
-      # resulting tree; only the commit hash differs (GitHub's own
-      # committer/timestamp), which is irrelevant for CI. If the base branch
-      # advances between event delivery and this fetch, the tree reflects the
-      # newer base (what a fresh merge would use), so it can differ slightly
-      # from the event-time merge ref. A conflicting PR fails loudly here,
-      # mirroring GitHub, which also cannot produce a merge ref for a conflicted
-      # PR.
-      - name: Reconstruct PR merge commit
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin "refs/pull/${{ github.event.pull_request.number }}/head"
-          git merge --no-ff --no-edit FETCH_HEAD
+          pr-number: ${{ github.event.pull_request.number }}
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -48,7 +48,12 @@ jobs:
       # The merge ref (refs/pull/N/merge) is lazily published by GitHub and can
       # be missing when a pull_request_target run starts. If checkout of that
       # ref fails, go-apidiff below never runs and the breaking-change gate
-      # silently passes. Reconstruct the merge commit deterministically instead.
+      # silently passes. Reconstruct the merge commit reliably instead.
+      # Merging head into base reproduces GitHub's merge ref (base = first
+      # parent, head = second) with a byte-identical tree; only the commit hash
+      # differs (GitHub's own committer/timestamp), which is irrelevant for CI.
+      # A conflicting PR fails loudly here, mirroring GitHub, which also cannot
+      # produce a merge ref for a conflicted PR.
       - name: Reconstruct PR merge commit
         run: |
           git config user.name "github-actions[bot]"
@@ -214,11 +219,13 @@ jobs:
   # job-level `if: always()` so the check ALWAYS reports a real pass/fail and is
   # never skipped. A conditional job-level `if:` would be unreliable (a skipped
   # job's status under branch protection varies by how the check is named), so
-  # gating lives in the step instead: the step only fails (exit 1) when its gate
-  # fires. Because validate can fail for infrastructure reasons (checkout of the
-  # merge ref, setup-go reading go.mod, gh pr view), always() keeps these jobs
-  # running so the required checks always get a signal rather than leaving the
-  # PR stuck in "Expected - Waiting for status".
+  # gating lives in the step instead: a step fails (exit 1) when its gate fires.
+  # Because validate can fail for infrastructure reasons (checkout or merge
+  # reconstruction, setup-go reading go.mod, gh pr view), these jobs also fail
+  # on `needs.validate.result == 'failure'/'cancelled'` so an infra failure
+  # blocks the PR loudly instead of silently passing the gate. always() keeps
+  # these jobs running so the required checks always get a real signal rather
+  # than leaving the PR stuck in "Expected - Waiting for status".
   block-invalid-title:
     name: Block invalid PR title
     needs: validate
@@ -227,6 +234,16 @@ jobs:
     permissions:
       contents: read
     steps:
+      # If validate crashed (checkout, merge reconstruction, setup-go, gh pr
+      # view), its error outputs are unset and the check above would silently
+      # pass. Turn any validate failure into an explicit, blocking signal so an
+      # infra problem can't mask an unmarked breaking change.
+      - name: Fail on validate job failure
+        if: needs.validate.result == 'failure' || needs.validate.result == 'cancelled'
+        run: |
+          echo "The validate job ${needs.validate.result}: PR title/API checks could not complete (checkout, merge reconstruction, or setup failed). Re-run the workflow."
+          exit 1
+
       - name: Fail on invalid PR title
         if: needs.validate.outputs.title-error != ''
         env:
@@ -244,6 +261,15 @@ jobs:
     permissions:
       contents: read
     steps:
+      # If validate crashed, its breaking-reason output is unset and the check
+      # above would silently pass. Turn any validate failure into an explicit,
+      # blocking signal so an infra problem can't mask an unmarked break.
+      - name: Fail on validate job failure
+        if: needs.validate.result == 'failure' || needs.validate.result == 'cancelled'
+        run: |
+          echo "The validate job ${needs.validate.result}: PR title/API checks could not complete (checkout, merge reconstruction, or setup failed). Re-run the workflow."
+          exit 1
+
       - name: Fail on unmarked breaking change
         if: needs.validate.outputs.breaking-reason != ''
         env:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -62,17 +62,9 @@ jobs:
       # and re-checking API diffs against rc bumps would otherwise cause false failures.
       - name: Determine if release PR
         id: is-release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          LABELS="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")')"
-          if [[ "$LABELS" == *"autorelease: pending"* ]]; then
-            echo "is-release=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is-release=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.github/actions/is-release-pr
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
 
       - name: Validate breaking change marking
         id: breaking-change

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -231,14 +231,13 @@ jobs:
       contents: read
     steps:
       # If validate crashed (checkout, merge reconstruction, setup-go, gh pr
-      # view), its error outputs are unset and the check above would silently
-      # pass. Turn any validate failure into an explicit, blocking signal so an
-      # infra problem can't mask an unmarked breaking change.
+      # view), its error outputs are unset and the check below would silently
+      # pass. Fail loudly so an infra problem can't mask an invalid title.
       - name: Fail on validate job failure
-        if: needs.validate.result == 'failure' || needs.validate.result == 'cancelled'
-        run: |
-          echo "The validate job ${needs.validate.result}: PR title/API checks could not complete (checkout, merge reconstruction, or setup failed). Re-run the workflow."
-          exit 1
+        uses: ./.github/actions/require-job-passed
+        with:
+          result: ${{ needs.validate.result }}
+          message: "The validate job ${{ needs.validate.result }}: PR title/API checks could not complete (checkout, merge reconstruction, or setup failed). Re-run the workflow."
 
       - name: Fail on invalid PR title
         if: needs.validate.outputs.title-error != ''
@@ -258,13 +257,13 @@ jobs:
       contents: read
     steps:
       # If validate crashed, its breaking-reason output is unset and the check
-      # above would silently pass. Turn any validate failure into an explicit,
-      # blocking signal so an infra problem can't mask an unmarked break.
+      # below would silently pass. Fail loudly so an infra problem can't mask an
+      # unmarked breaking change.
       - name: Fail on validate job failure
-        if: needs.validate.result == 'failure' || needs.validate.result == 'cancelled'
-        run: |
-          echo "The validate job ${needs.validate.result}: PR title/API checks could not complete (checkout, merge reconstruction, or setup failed). Re-run the workflow."
-          exit 1
+        uses: ./.github/actions/require-job-passed
+        with:
+          result: ${{ needs.validate.result }}
+          message: "The validate job ${{ needs.validate.result }}: PR title/API checks could not complete (checkout, merge reconstruction, or setup failed). Re-run the workflow."
 
       - name: Fail on unmarked breaking change
         if: needs.validate.outputs.breaking-reason != ''

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -46,9 +46,7 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
+        uses: ./.github/actions/setup-go
 
       - name: Check for breaking API changes
         id: apidiff

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -51,6 +51,7 @@ jobs:
         run: gotestsum --format github-actions --format-icons hivis -- -race -shuffle on -timeout 600s -v ./...
 
       - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/upload-codecov
         with:
           flags: unit,${{ matrix.os-flag }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,13 +40,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        uses: ./.github/actions/setup-go
         with:
-          cache: true
-          go-version-file: "go.mod"
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f # v1.13.0
+          install-gotestsum: 'true'
 
       - name: Test
         run: gotestsum --junitfile junit.xml --format github-actions --format-icons hivis -- -shuffle on -timeout 600s -v -coverprofile coverage.out -covermode atomic ./...

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -51,32 +51,7 @@ jobs:
         run: gotestsum --format github-actions --format-icons hivis -- -race -shuffle on -timeout 600s -v ./...
 
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        uses: ./.github/actions/upload-codecov
         with:
-          files: coverage.out
           flags: unit,${{ matrix.os-flag }}
-          codecov_yml_path: .github/codecov.yml
-          disable_search: true
-          fail_ci_if_error: false
-          use_oidc: true
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
-        with:
-          files: junit.xml
-          flags: unit,${{ matrix.os-flag }}
-          codecov_yml_path: .github/codecov.yml
-          disable_search: true
-          fail_ci_if_error: false
-          use_oidc: true
-
-      - name: Upload test artifacts
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-results-${{ matrix.os }}
-          path: |
-            junit.xml
-            coverage.out
+          artifact-name: test-results-${{ matrix.os }}

--- a/.github/workflows/validate-release-pr.yml
+++ b/.github/workflows/validate-release-pr.yml
@@ -21,17 +21,9 @@ jobs:
       # payload's labels array can be empty on synchronize/opened events).
       - name: Determine if release PR
         id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          LABELS="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")')"
-          if [[ "$LABELS" == *"autorelease: pending"* ]]; then
-            echo "is-release=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is-release=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.github/actions/is-release-pr
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
 
       - name: Checkout code
         if: steps.check.outputs.is-release == 'true'


### PR DESCRIPTION
- Reconstructed the PR merge commit deterministically (checkout-pr-merge action). The old code checked out the refs/pull/N/merge ref, which GitHub publishes lazily and can be momentarily missing when a pull_request_target run starts — causing transient "couldn't find remote ref" failures. We now check out the base branch and merge the always-available refs/pull/N/head with --no-ff, which reproduces the merge GitHub would use (same tree, base = first parent) without the race.
- Removed silent-failure paths. Several gates previously passed silently when an upstream job crashed (leaving its outputs unset):
- The pr-title-check block jobs and the integration-tests aggregator now fail loudly whenever their prerequisite job fails or is cancelled, not just on a detected error.
- A go-apidiff crash now blocks instead of silently letting an unmarked breaking change slip past the gate.
- Hardened the ungated check-changes job. It no longer materializes (potentially fork-supplied) PR code before environment approval; it fetches the changed-file list via the API instead.
- Follow-up checkouts/fetches are instrumentation and comment-only accuracy fixes.
Moved to composite actions (DRY:
Reusable local composite actions under .github/actions/, so pinned action versions, config, and logic live in one place:
- checkout-pr-merge — base checkout + merge reconstruction
- require-job-passed — fail softly-gated jobs when a prerequisite crashed
- setup-go — Go toolchain (+ optional gotestsum)
- parse-model — opencode model allowlist/default resolution
- run-opencode — checkout + OpenCode invocation wiring
- is-release-pr — release-please label detection
- upload-codecov — coverage/test-results/artifacts upload
Security note: integration tests still run only under the integration-tests environment's required-reviewer approval for PR-triggered runs; push/schedule runs remain ungated as before. No behavior changes to which tests run or the existing gates — this is purely about making CI reliable and consistent, not changing test scope.