### PR TITLE
ci: add bootstrap checkout before local composite actions

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -17,6 +17,11 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Checkout (bootstrap for local actions)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Parse model from comment
         id: model
         uses: ./.github/actions/parse-model

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -97,6 +97,15 @@ jobs:
       id-token: write # Required for OIDC token to upload coverage and test results
       issues: write # For creating/closing failure issues
     steps:
+      # A local composite action's metadata must already exist in the workspace,
+      # so a normal (marketplace) checkout must run before the first local action
+      # below can be resolved. This bootstrap is not the functional checkout:
+      # checkout-pr-merge re-checks out the base and reconstructs the merge.
+      - name: Checkout (bootstrap for local actions)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.ref || github.ref }}
+
       - name: Checkout and reconstruct PR merge
         uses: ./.github/actions/checkout-pr-merge
         with:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -11,6 +11,11 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Checkout (bootstrap for local actions)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Check account age
         id: account
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -20,6 +20,11 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Checkout (bootstrap for local actions)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Parse model from comment
         id: model
         uses: ./.github/actions/parse-model

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -40,6 +40,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout (bootstrap for local actions)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Checkout and reconstruct PR merge
         uses: ./.github/actions/checkout-pr-merge
         with:
@@ -224,6 +229,9 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout (bootstrap for local actions)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       # If validate crashed (checkout, merge reconstruction, setup-go, gh pr
       # view), its error outputs are unset and the check below would silently
       # pass. Fail loudly so an infra problem can't mask an invalid title.
@@ -250,6 +258,9 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout (bootstrap for local actions)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       # If validate crashed, its breaking-reason output is unset and the check
       # below would silently pass. Fail loudly so an infra problem can't mask an
       # unmarked breaking change.

--- a/.github/workflows/validate-release-pr.yml
+++ b/.github/workflows/validate-release-pr.yml
@@ -17,6 +17,11 @@ jobs:
     name: Validate go.mod for Release
     runs-on: ubuntu-latest
     steps:
+      # Bootstrap checkout so the local composite action below (is-release-pr)
+      # can be resolved; its action.yml must already exist in the workspace.
+      - name: Checkout (bootstrap for local actions)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       # Runtime check of the PR's current labels (authoritative; the event
       # payload's labels array can be empty on synchronize/opened events).
       - name: Determine if release PR


### PR DESCRIPTION
Local composite actions (./.github/actions/*) are resolved by reading their action.yml from the runner workspace, which is empty until something checks out the repo. Jobs that used a local composite action as their first step failed during job preparation with 'Did you forget to run actions/checkout?' (e.g. integration-tests run-integration-tests, pr-title-check validate, code-review, opencode, issue-triage, validate-release-pr).

Prepend a marketplace actions/checkout before the first local composite action in each affected job so the local action metadata is resolvable. Jobs that deliberately avoid checkout (integration-tests check-changes, pr-title-check comment) are left untouched for the fork-safety reasoning already documented.