### PR TITLE
ci: Run codeql on v*-draft branches

### DIFF
--- a/.github/actions/run-opencode/action.yml
+++ b/.github/actions/run-opencode/action.yml
@@ -5,6 +5,9 @@ description: >
   GitHub action. Centralizes the pinned opencode action, the OPENROUTER_API_KEY
   wiring, and the checkout configuration so they are maintained in one place.
 inputs:
+  openrouter_api_key:
+    description: OpenRouter API key used to authenticate OpenCode.
+    required: true
   model:
     description: Model to run OpenCode with.
     required: true
@@ -31,7 +34,7 @@ runs:
     - name: Run OpenCode
       uses: anomalyco/opencode/github@7902e04c3a67f7c69726bc955efb46e29214c797 # v1.18.10
       env:
-        OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter_api_key }}
       with:
         model: ${{ inputs.model }}
         share: ${{ inputs.share }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Checkout and run OpenCode
         uses: ./.github/actions/run-opencode
         with:
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           model: ${{ steps.model.outputs.model }}
           prompt: |
             REVIEWER HINT: ${{ github.event.comment.body }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - v*-draft
   pull_request:
     branches:
       - main

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,7 +66,7 @@ jobs:
           # approval), so untrusted fork code must never be materialized here.
           # A failure surfaces loudly (no || true) and is caught by the
           # integration-tests aggregator rather than silently skipping.
-          CHANGED_FILES="$(gh api --paginate "repos/{owner}/{repo}/pulls/$PR_NUMBER/files" --jq '.[].filename')"
+          CHANGED_FILES="$(gh api --paginate "repos/${{ github.repository }}/pulls/$PR_NUMBER/files" --jq '.[].filename')"
           echo "Changed files:"
           echo "$CHANGED_FILES"
           CODE_CHANGES=$(echo "$CHANGED_FILES" | grep -v '^docs/' | grep -v '\.md$' | grep -v '^LICENSE$' | grep -v '^\.github/' || true)

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -40,6 +40,7 @@ jobs:
         if: steps.account.outputs.allowed == 'true'
         uses: ./.github/actions/run-opencode
         with:
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           model: openrouter/~deepseek/deepseek-v4-flash-latest
           agent: plan
           prompt: |

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -34,4 +34,5 @@ jobs:
       - name: Checkout and run OpenCode
         uses: ./.github/actions/run-opencode
         with:
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           model: ${{ steps.model.outputs.model }}


### PR DESCRIPTION
Run codeql on v*-draft branches since that is where major work will happen for release candidates.